### PR TITLE
Full output

### DIFF
--- a/hitime/hitime.py
+++ b/hitime/hitime.py
@@ -104,6 +104,9 @@ parser.add_argument('--minSample',
                     default=DEFAULTMINSAMPLE,
                     action='store',
                     type=float)
+parser.add_argument('--fullOutput',
+                    action='store_true',
+                    help='output all points, including those with zero scores')
 
 
 def main(MPI=None):
@@ -181,7 +184,7 @@ def main(MPI=None):
                 raw_data, scores = COMM.recv(source=MPI.ANY_SOURCE, status=status)
                 source = status.Get_source()
             if raw_data is not None:
-                md_io.writeResults(data_out, raw_data, scores)
+                md_io.writeResults(data_out, raw_data, options, scores)
 
             ## Read data chunk
             try:

--- a/hitime/md_io.py
+++ b/hitime/md_io.py
@@ -117,6 +117,8 @@ def MZMLtoSpectrum(options):
     time = 0
     msrun = pymzml.run.Reader(filename)
     for n,spectrum in enumerate(msrun):
+        if spectrum['id'] == 'TIC': # This ID does not hold spectrum data
+            continue                # and should be skipped
         mzData = np.array(spectrum.mz, dtype="float32")
         intData = np.array(spectrum.i, dtype="uint64")
         points += len(intData)

--- a/hitime/md_io.py
+++ b/hitime/md_io.py
@@ -94,13 +94,13 @@ def parseMZDATA(options):
     return result
 
 
-def writeResults(stream, spectrum, scores=None):
+def writeResults(stream, spectrum, options, scores=None):
     if scores is not None:
         rt = spectrum.time
         for mz, amp, val in zip(spectrum.mzs, spectrum.intensities, scores):
 #            if val > 0.0:
 #                print >> stream, '{}, {}, {}, {}'.format(rt, mz, amp, val)
-            if val[0] > 0.0:
+            if val[0] > 0.0 or options.fullOutput:
                 print >> stream, '{}, {}, {}, {}'.format(rt, mz, amp, ', '.join([str(v) for v in val]))
     else:
         rt = spectrum.time


### PR DESCRIPTION
I found it useful when comparing results to have access to the full results including points with zero scores so I have added an option to the Python program to do that.

There is also a bug in the pymzml package that an extra spectrum is read in which does not contain mass spec data (I think it has something to do with how the file reading is done). I don't think this affects the scoring as it is the last spectrum but it does change the number of output points so I have made a small fix which skips this extra spectrum. 

I'm not sure if this is something you want to include but I thought I would let you know what I found.
